### PR TITLE
Improve code quality of Duke parseCommand method

### DIFF
--- a/src/main/java/Duke/Disk.java
+++ b/src/main/java/Duke/Disk.java
@@ -62,7 +62,7 @@ public class Disk {
         }
         Scanner fileScanner = new Scanner(file);
         while (fileScanner.hasNextLine()) {
-            String cmd = fileScanner.nextLine(); // e.g. T | 1 | description
+            String cmd = fileScanner.nextLine();
             String [] separator = cmd.split(",", 4);
             Task currTask = null;
             switch(separator[0]) {

--- a/src/main/java/Duke/Duke.java
+++ b/src/main/java/Duke/Duke.java
@@ -17,7 +17,7 @@ public class Duke {
     private static final UiPrinter myUiPrinter = new UiPrinter();
     private static Disk myDisk;
     /**
-     * Empty contructor for Duke
+     * Empty constructor for Duke
      */
     public Duke() {
         myDisk = new Disk("src/main/java/data/savedTasks.txt", myListStorage);
@@ -66,50 +66,56 @@ public class Duke {
      * @throws WrongCommandException if user enters invalid commands
      */
     public static void parseCommand() throws WrongCommandException {
-
+        int taskNumber;
         Scanner myScanner = new Scanner(System.in);
         Commands commands = new Commands(myListStorage, myPrinter);
 
         while (myScanner.hasNextLine()) {
             String cmd = myScanner.nextLine();
             try {
-                if (cmd.equals("bye")) {
-                    commands.cmdBye();
-                    myDisk.saveToDisk();
-                    break;
-                } else if (cmd.contains("todo")) {
+                String[] cmds = Parser.parseCmdAndDes(cmd);
+                switch (cmds[0]) {
+                case "todo":
                     commands.cmdTodo(cmd);
                     myDisk.saveToDisk();
-                } else if (cmd.contains("event")) {
-                    commands.cmdEvent(cmd);
-                    myDisk.saveToDisk();
-                } else if (cmd.contains("deadline")) {
+                    break;
+                case "deadline":
                     commands.cmdDeadline(cmd);
                     myDisk.saveToDisk();
-                } else if (cmd.contains("list")) {
-                    commands.cmdList();
-                } else if (cmd.contains("find")) {
+                    break;
+                case "event":
+                    commands.cmdEvent(cmd);
+                    myDisk.saveToDisk();
+                    break;
+                case "mark":
+                    taskNumber = Character.getNumericValue(cmd.charAt(cmd.length() - 1));
+                    commands.cmdMark(taskNumber);
+                    myDisk.saveToDisk();
+                    break;
+                case "unmark":
+                    taskNumber = Character.getNumericValue(cmd.charAt(cmd.length() - 1));
+                    commands.cmdUnmark(taskNumber);
+                    myDisk.saveToDisk();
+                    break;
+                case "delete":
+                    taskNumber = Character.getNumericValue(cmd.charAt(cmd.length() - 1));
+                    commands.cmdDelete(taskNumber);
+                    myDisk.saveToDisk();
+                    break;
+                case "find":
                     commands.cmdFind(cmd);
-                } else {
-                    int taskNumber = Character.getNumericValue(cmd.charAt(cmd.length() - 1));
-                    if (cmd.contains("mark")) {
-                        if (cmd.contains("unmark")) {
-                            commands.cmdUnmark(taskNumber);
-                            myDisk.saveToDisk();
-                        } else {
-                            commands.cmdMark(taskNumber);
-                            myDisk.saveToDisk();
-                        }
-                    } else if (cmd.contains("delete")) {
-                        commands.cmdDelete(taskNumber);
-                        myDisk.saveToDisk();
-                    } else {
-                        throw new WrongCommandException("Invalid Command");
-                    }
+                    break;
+                case "list":
+                    commands.cmdList();
+                    break;
+                case "bye":
+                    commands.cmdBye();
+                    break;
+                default:
+                    throw new WrongCommandException("Invalid Command");
                 }
             } catch (EmptyMessageException | WrongDateFormatException e) {
                 myPrinter.printExceptions(e);
-                //cmd = myScanner.nextLine();
             }
         }
     }

--- a/src/main/java/data/savedTasks.txt
+++ b/src/main/java/data/savedTasks.txt
@@ -1,3 +1,2 @@
-T,0,run 10km
 T,0,run more
 D,0,assignment 1,2022-02-09


### PR DESCRIPTION
Instead of using contains(), where users could input something like
"tododeadline <task>" and Duke still allows it, using switch statements
will only process the first argument as the user-intended command.